### PR TITLE
adds tabs to topics pages

### DIFF
--- a/sites/all/modules/custom/topics_collection_list/topics_collection_list.views_default.inc
+++ b/sites/all/modules/custom/topics_collection_list/topics_collection_list.views_default.inc
@@ -796,9 +796,15 @@ function topics_collection_list_views_default_views() {
   $handler->display->display_options['query']['options']['pure_distinct'] = TRUE;
   $handler->display->display_options['defaults']['style_plugin'] = FALSE;
   $handler->display->display_options['style_plugin'] = 'list';
+  $handler->display->display_options['style_options']['row_class'] = 'tab-header-and-content';
+  $handler->display->display_options['style_options']['default_row_class'] = FALSE;
+  $handler->display->display_options['style_options']['row_class_special'] = FALSE;
+  $handler->display->display_options['style_options']['class'] = 'accordion-tabs';
+  $handler->display->display_options['style_options']['wrapper_class'] = '';
   $handler->display->display_options['defaults']['style_options'] = FALSE;
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
   $handler->display->display_options['row_plugin'] = 'fields';
+  $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: Entity Reference: Referencing entity */
@@ -810,24 +816,33 @@ function topics_collection_list_views_default_views() {
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
   $handler->display->display_options['fields']['title']['field'] = 'title';
-  $handler->display->display_options['fields']['title']['relationship'] = 'field_division_holdings_target_id';
   $handler->display->display_options['fields']['title']['label'] = '';
-  $handler->display->display_options['fields']['title']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['path'] = '#';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title']['element_wrapper_type'] = 'h2';
-  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_wrapper_class'] = 'tab-link [path]';
+  $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
   /* Field: Content: Body */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';
-  $handler->display->display_options['fields']['body']['relationship'] = 'field_division_holdings_target_id';
   $handler->display->display_options['fields']['body']['label'] = '';
   $handler->display->display_options['fields']['body']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['body']['element_wrapper_type'] = 'div';
+  $handler->display->display_options['fields']['body']['element_wrapper_class'] = 'tab-content';
+  $handler->display->display_options['fields']['body']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['body']['settings'] = array(
-    'trim_length' => '600',
+    'class' => '',
   );
+  /* Field: Content: Path */
+  $handler->display->display_options['fields']['path']['id'] = 'path';
+  $handler->display->display_options['fields']['path']['table'] = 'node';
+  $handler->display->display_options['fields']['path']['field'] = 'path';
+  $handler->display->display_options['fields']['path']['label'] = '';
+  $handler->display->display_options['fields']['path']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['path']['element_label_colon'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: Content: Nid */

--- a/sites/all/themes/rbsc/assets/source/scripts/rbsc.behaviors.js
+++ b/sites/all/themes/rbsc/assets/source/scripts/rbsc.behaviors.js
@@ -45,5 +45,31 @@
     }
   };
 
+  Drupal.behaviors.rbscTabs = {
+    attach: function (context, settings) {
+      $(document).ready(function () {
+          var path = '-' + document.referrer.substr(document.referrer.lastIndexOf('/') + 1);
+          console.log(path);
+
+          $('.accordion-tabs').each(function(index) {
+            $(this).children('li').first().children('h2').addClass('is-active').next().addClass('is-open').show();
+          });
+
+          $('.accordion-tabs').on('click', 'li > h2.tab-link', function(event) {
+            event.preventDefault();
+            if (!$(this).hasClass('is-active')) {
+              var accordionTabs = $(this).closest('.accordion-tabs');
+              accordionTabs.find('.is-open').removeClass('is-open').hide();
+
+              $(this).next().toggleClass('is-open').toggle();
+              accordionTabs.find('.is-active').removeClass('is-active');
+              $(this).addClass('is-active');
+            }
+
+          });
+        });
+    }
+  }
+
 
 })(jQuery);

--- a/sites/all/themes/rbsc/assets/source/styles/components/_tabs.scss
+++ b/sites/all/themes/rbsc/assets/source/styles/components/_tabs.scss
@@ -1,0 +1,102 @@
+.accordion-tabs {
+  $base-border-color: gainsboro !default;
+  $base-border-radius: 3px !default;
+  $base-background-color: white !default;
+  $base-spacing: 1.5em !default;
+  $action-color: #477DCA !default;
+  $dark-gray: #333 !default;
+  $light-gray: #DDD !default;
+  $medium-screen: em(640) !default;
+  $tab-border: 1px solid $base-border-color;
+  $tab-content-background: lighten($light-gray, 10);
+  $tab-active-background: $tab-content-background;
+  $tab-inactive-color: $base-background-color;
+  $tab-inactive-hover-color: darken($light-gray, 5);
+  $tab-mode: $bp-large;
+
+  @include clearfix;
+  line-height: 1.5;
+  margin-bottom: $base-spacing;
+  padding: 0;
+
+  @include breakpoint(max-width $tab-mode) {
+    border-radius: $base-border-radius;
+    border: $tab-border;
+  }
+
+  .tab-header-and-content {
+    list-style: none;
+
+    @include breakpoint($tab-mode) {
+      display: inline;
+    }
+
+    &:first-child .tab-link {
+      border-top-left-radius: $base-border-radius;
+      border-top-right-radius: $base-border-radius;
+
+      @include breakpoint(max-width $tab-mode) {
+        border-top: 0;
+      }
+    }
+
+    &:last-child .tab-link {
+      @include breakpoint(max-width $tab-mode) {
+        border-bottom-left-radius: $base-border-radius;
+        border-bottom-right-radius: $base-border-radius;
+      }
+    }
+  }
+
+  .tab-link {
+    background-color: $tab-inactive-color;
+    border-top: $tab-border;
+    color: $dark-gray;
+    display: block;
+    font-weight: bold;
+    padding: 1em; // $base-spacing/2 $gutter/2;
+    text-decoration: none;
+    margin:0;
+
+    @include breakpoint($tab-mode) {
+      @include inline-block;
+      border-top-left-radius: $base-border-radius;
+      border-top-right-radius: $base-border-radius;
+      border-top: 0;
+    }
+
+    &:hover {
+      color: $action-color;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &.is-active {
+      background-color: $tab-active-background;
+
+      @include breakpoint($tab-mode) {
+        background-color: $tab-active-background;
+        border: $tab-border;
+        border-bottom-color: $tab-active-background;
+        margin-bottom: -1px;
+      }
+    }
+  }
+
+  .tab-content {
+    background: $tab-content-background;
+    display: none;
+    padding: 2em; //$base-spacing $gutter;
+    width: 100%;
+
+    @include breakpoint($tab-mode) {
+      border-bottom-left-radius: $base-border-radius;
+      border-bottom-right-radius: $base-border-radius;
+      border-top-right-radius: $base-border-radius;
+      border: $tab-border;
+      float: left;
+    }
+  }
+}

--- a/sites/all/themes/rbsc/assets/source/styles/rbsc.styles.scss
+++ b/sites/all/themes/rbsc/assets/source/styles/rbsc.styles.scss
@@ -34,5 +34,6 @@
 @import "components/publications";
 @import "components/striped-rows";
 @import "components/topics";
+@import "components/tabs";
 
 @import "components/menus/menu--main";


### PR DESCRIPTION
This does not address the auto-activation of a tab that corresponds to a referring division.  I would like to use the division path since that's where they will be coming from.  I could not figure out how to pull in the Division path, even though it's an Entity Reference of Division Holdings, which is an Entity Reference of Topics.  Will try again tomorrow.

@kevinreiss I noticed that the view for the Topics' Holdings tabs is different on dev than it was in my local machine.  Were you working on there?  Just be careful not to lose any work when you revert features.
