### PR TITLE
Adding sed commands for removing libweb5 urls from the special collections database

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,10 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.3.4)
+    airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     byebug (11.1.1)
-    capistrano (3.11.2)
+    capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -22,15 +22,15 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.3)
-    i18n (1.6.0)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.1)
-    net-scp (2.0.0)
-      net-ssh (>= 2.6.5, < 6.0.0)
-    net-ssh (5.2.0)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.1.0)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -39,7 +39,7 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.0)
+    rake (13.0.6)
     regexp_parser (1.6.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -58,7 +58,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sshkit (1.20.0)
+    sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     xpath (3.2.0)
@@ -76,4 +76,4 @@ DEPENDENCIES
   selenium-webdriver
 
 BUNDLED WITH
-   2.0.1
+   2.2.27

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -186,7 +186,6 @@ namespace :drupal do
         sql_file_name = gz_file_name.sub('.gz','')
         upload! File.join(ENV['SQL_DIR'], gz_file_name), "/tmp/#{gz_file_name}"
         execute "gzip -f -d /tmp/#{gz_file_name}"
-        execute "/home/deploy/sql/set_permission.sh"
         execute "drush -r #{release_path} sql-cli < /tmp/#{sql_file_name}"
       end
     end

--- a/sed_commands_libweb5.sed
+++ b/sed_commands_libweb5.sed
@@ -1,0 +1,2 @@
+s/http\:\/\/libweb5\.princeton\.edu/https\:\/\/library\.princeton\.edu/g
+s/https\:\/\/libweb5\.princeton\.edu/https\:\/\/library\.princeton\.edu/g


### PR DESCRIPTION
Also updated capistrano to run locally

To run the sed command `LC_ALL=C sed -i .other -f sed_commands_libweb5.sed dump.sql`

refs https://github.com/pulibrary/special_collections/issues/679