### PR TITLE
update htaccess for datadog

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -117,6 +117,7 @@ DirectoryIndex index.php index.html index.htm
 
   # Pass all requests not referring directly to files in the filesystem to
   # index.php. Clean URLs are handled in drupal_environment_initialize().
+  RewriteCond %{REQUEST_URI} !=/server-status
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteCond %{REQUEST_URI} !=/favicon.ico


### PR DESCRIPTION
Updates the htaccess file to allow datadog access to the apache server status page

This will hopefully alleviate the phantom monitor errors we are seeing with the special collections web site.